### PR TITLE
feat: fix several bugs under openwrt's latest stable 21.02 #121

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -44,7 +44,7 @@ define Package/luci-app-adguardhome/install
 	$(INSTALL_DIR) $(1)/
 	cp -pR ./root/* $(1)/
 	$(INSTALL_DIR) $(1)/usr/lib/lua/luci/i18n
-	po2lmo ./po/zh-cn/AdGuardHome.po $(1)/usr/lib/lua/luci/i18n/AdGuardHome.zh-cn.lmo
+	po2lmo ./po/zh_Hans/AdGuardHome.po $(1)/usr/lib/lua/luci/i18n/AdGuardHome.zh-cn.lmo
 endef
 
 define Package/luci-app-adguardhome/postinst

--- a/luasrc/controller/AdGuardHome.lua
+++ b/luasrc/controller/AdGuardHome.lua
@@ -18,7 +18,7 @@ end
 function get_template_config()
 	local b
 	local d=""
-	for cnt in io.lines("/tmp/resolv.conf.auto") do
+	for cnt in io.lines("/tmp/resolv.conf.d/resolv.conf.auto") do
 		b=string.match (cnt,"^[^#]*nameserver%s+([^%s]+)$")
 		if (b~=nil) then
 			d=d.."  - "..b.."\n"

--- a/luasrc/model/cbi/AdGuardHome/manual.lua
+++ b/luasrc/model/cbi/AdGuardHome/manual.lua
@@ -8,7 +8,7 @@ require("table")
 function gen_template_config()
 	local b
 	local d=""
-	for cnt in io.lines("/tmp/resolv.conf.auto") do
+	for cnt in io.lines("/tmp/resolv.conf.d/resolv.conf.auto") do
 		b=string.match (cnt,"^[^#]*nameserver%s+([^%s]+)$")
 		if (b~=nil) then
 			d=d.."  - "..b.."\n"

--- a/luasrc/view/AdGuardHome/AdGuardHome_check.htm
+++ b/luasrc/view/AdGuardHome/AdGuardHome_check.htm
@@ -46,7 +46,7 @@ XHR.poll(3, '<%=url([[admin]], [[services]], [[AdGuardHome]], [[check]])%>', nul
 	function(x, data) {
 		var lv = document.getElementById('cbid.logview.1.conf');
 		if (x.responseText && lv) {
-			if (x.responseText=="\u0000"){
+			if (x.responseText=="\u0000" && this.XHR._q){
 				for(j = 0,len=this.XHR._q.length; j < len; j++) {
 					if (this.XHR._q[j].url == '<%=url([[admin]], [[services]], [[AdGuardHome]], [[check]])%>'){
 						this.XHR._q.splice(j,1);

--- a/po/zh_Hans/AdGuardHome.po
+++ b/po/zh_Hans/AdGuardHome.po
@@ -1,0 +1,266 @@
+#/cgi-bin/luci/admin/services/AdGuardHome
+msgid "Base Setting"
+msgstr "基础设置"
+
+msgid "Log"
+msgstr "日志"
+
+msgid "Manual Config"
+msgstr "手动设置"
+
+msgid "Free and open source, powerful network-wide ads & trackers blocking DNS server."
+msgstr "免费开源，功能强大的全网络广告和跟踪程序拦截DNS服务器"
+
+msgid "RUNNING"
+msgstr "运行中"
+
+msgid "NOT RUNNING"
+msgstr "未运行"
+
+msgid "Redirected"
+msgstr "已重定向"
+
+msgid "Not redirect"
+msgstr "未重定向"
+
+msgid "Collecting data..."
+msgstr "获取数据中..."
+
+msgid "Enable"
+msgstr "启用"
+
+msgid "Browser management port"
+msgstr "网页管理端口"
+
+msgid "Update"
+msgstr "更新"
+#button change
+msgid "Update core version"
+msgstr "更新核心版本"
+
+msgid "Check..."
+msgstr "检查中..."
+
+msgid "Updated"
+msgstr "已更新"
+
+#button hide
+msgid "Force update"
+msgstr "强制更新"
+
+msgid "Fast config"
+msgstr "快速配置"
+#
+msgid "core version:"
+msgstr "核心版本:"
+#description change
+msgid "no config"
+msgstr "没有配置文件"
+msgid "no core"
+msgstr "没有核心"
+#
+msgid "Redirect"
+msgstr "重定向"
+#inlist
+msgid "none"
+msgstr "无"
+
+msgid "Run as dnsmasq upstream server"
+msgstr "作为dnsmasq的上游服务器"
+
+msgid "Redirect 53 port to AdGuardHome"
+msgstr "重定向53端口到AdGuardHome"
+
+msgid "Use port 53 replace dnsmasq"
+msgstr "使用53端口替换dnsmasq"
+#
+msgid "AdGuardHome redirect mode"
+msgstr "AdGuardHome重定向模式"
+
+msgid "Bin Path"
+msgstr "执行文件路径"
+
+msgid "AdGuardHome Bin path if no bin will auto download"
+msgstr "AdGuardHome 执行文件路径 如果没有执行文件将自动下载"
+
+msgid "use upx to compress bin after download"
+msgstr "下载后使用upx压缩执行文件"
+#inlist
+msgid "compress faster"
+msgstr "快速压缩"
+
+msgid "compress better"
+msgstr "更好的压缩"
+
+msgid "compress best(can be slow for big files)"
+msgstr "最好的压缩(大文件可能慢)"
+
+msgid "try all available compression methods & filters [slow]"
+msgstr "尝试所有可能的压缩方法和过滤器[慢]"
+
+msgid "try even more compression variants [very slow]"
+msgstr "尝试更多变体压缩手段[很慢]"
+
+msgid "bin use less space,but may have compatibility issues"
+msgstr "减小执行文件空间占用，但是可能压缩后有兼容性问题"
+#
+msgid "Config Path"
+msgstr "配置文件路径"
+
+msgid "AdGuardHome config path"
+msgstr "AdGuardHome 配置文件路径"
+
+msgid "Work dir"
+msgstr "工作目录"
+
+msgid "AdGuardHome work dir include rules,audit log and database"
+msgstr "AdGuardHome 工作目录包含规则，审计日志和数据库"
+
+msgid "Runtime log file"
+msgstr "运行日志"
+
+msgid "AdGuardHome runtime Log file if 'syslog': write to system log;if empty no log"
+msgstr "AdGuardHome 运行日志 如果填syslog将写入系统日志；如果空则不记录日志"
+
+msgid "Verbose log"
+msgstr "详细日志"
+#hide div
+msgid "Add gfwlist"
+msgstr "加入gfw列表"
+
+msgid "Add"
+msgstr "添加"
+
+msgid "Added"
+msgstr "已添加"
+
+msgid "Not added"
+msgstr "未添加"
+#hide div
+msgid "Del gfwlist"
+msgstr "删除gfw列表"
+
+msgid "Del"
+msgstr "删除"
+#hide div
+msgid "Gfwlist upstream dns server"
+msgstr "gfw列表上游服务器"
+
+msgid "Gfwlist domain upstream dns service"
+msgstr "gfw列表域名上游服务器"
+#hide div
+msgid "Change browser management password"
+msgstr "改变网页登录密码"
+
+msgid "Culculate"
+msgstr "计算"
+##button change
+msgid "Load culculate model"
+msgstr "载入计算模块"
+
+msgid "loading..."
+msgstr "载入中"
+
+msgid "Please save/apply"
+msgstr "请提交"
+
+msgid "is empty"
+msgstr "为空"
+
+msgid "Press load culculate model and culculate finally save/apply"
+msgstr "按载入计算模块 然后计算 最后保存/提交"
+#
+msgid "Keep files when system upgrade"
+msgstr "系统升级时保留文件"
+#checkbox
+msgid "core bin"
+msgstr "核心执行文件"
+
+msgid "config file"
+msgstr "配置文件"
+
+msgid "log file"
+msgstr "日志文件"
+
+msgid "querylog.json"
+msgstr "审计日志.json"
+#
+msgid "On boot when network ok restart"
+msgstr "开机后网络准备好时重启"
+
+msgid "Backup workdir files when shutdown"
+msgstr "在关机时备份工作目录文件"
+
+msgid "Will be restore when workdir/data is empty"
+msgstr "在工作目录/data为空的时候恢复"
+
+msgid "Backup workdir path"
+msgstr "工作目录备份路径"
+
+msgid "Crontab task"
+msgstr "计划任务"
+
+msgid "Auto update core"
+msgstr "自动升级核心"
+
+msgid "Auto tail querylog"
+msgstr "自动截短查询日志"
+
+msgid "Auto tail runtime log"
+msgstr "自动截短运行日志"
+
+msgid "Auto update ipv6 hosts and restart adh"
+msgstr "自动更新ipv6主机并重启adh"
+
+msgid "Auto update gfwlist and restart adh"
+msgstr "自动更新gfw列表并重启adh"
+
+msgid "Please change time and args in crontab"
+msgstr "请在计划任务中修改时间和参数"
+
+msgid "Download links for update"
+msgstr "升级用的下载链接"
+
+#/cgi-bin/luci/admin/services/AdGuardHome/log/
+msgid "reverse"
+msgstr "逆序"
+
+msgid "localtime"
+msgstr "本地时间"
+
+msgid "Please add log path in config to enable log"
+msgstr "请在设置里填写日志路径以启用日志"
+
+msgid "dellog"
+msgstr "删除日志"
+
+msgid "download log"
+msgstr "下载日志"
+
+#/cgi-bin/luci//admin/services/AdGuardHome/manual/
+msgid "Use template"
+msgstr "使用模板"
+#hide button
+msgid "Reload Config"
+msgstr "重新载入配置"
+
+msgid "WARNING!!! no bin found apply config will not be test"
+msgstr "警告！！！未找到执行文件，提交配置将不会进行校验"
+#unused
+msgid "Change browser management username"
+msgstr "改变网页登录用户名"
+
+msgid "Username"
+msgstr "用户名"
+
+msgid "Check Config"
+msgstr "检查配置"
+
+msgid "unknown"
+msgstr "未知"
+
+msgid "Keep database when system upgrade"
+msgstr "系统升级时保留数据"
+
+msgid "Boot delay until network ok"
+msgstr "开机时直到网络准备好再启动"

--- a/root/etc/init.d/AdGuardHome
+++ b/root/etc/init.d/AdGuardHome
@@ -49,7 +49,7 @@ stop_forward_dnsmasq()
 	uci del_list dhcp.@dnsmasq[0].server=$addr 2>/dev/null
 	addrlist="`uci get dhcp.@dnsmasq[0].server 2>/dev/null`"
 	if [ -z "$addrlist" ] ; then
-		uci set dhcp.@dnsmasq[0].resolvfile=/tmp/resolv.conf.auto 2>/dev/null
+		uci set dhcp.@dnsmasq[0].resolvfile=/tmp/resolv.conf.d/resolv.conf.auto 2>/dev/null
 		uci delete dhcp.@dnsmasq[0].noresolv 2>/dev/null
 	fi
 	uci commit dhcp
@@ -360,11 +360,11 @@ testbackup(){
 restore()
 {
 	config_get workdir $CONFIGURATION workdir "/usr/bin/AdGuardHome"
-	config_get backupwdpath $CONFIGURATION backupwdpath "/usr/bin/AdGuardHome"
+	config_get backupwdpath $CONFIGURATION workdir "/usr/bin/AdGuardHome"
 	cp -u -r -f $backupwdpath/data $workdir
 }
 backup() {
-	config_get backupwdpath $CONFIGURATION backupwdpath "/usr/bin/AdGuardHome"
+	config_get backupwdpath $CONFIGURATION workdir "/usr/bin/AdGuardHome"
 	mkdir -p $backupwdpath/data
 	config_get workdir $CONFIGURATION workdir "/usr/bin/AdGuardHome"
 	config_get backupfile $CONFIGURATION backupfile ""

--- a/root/usr/share/AdGuardHome/update_core.sh
+++ b/root/usr/share/AdGuardHome/update_core.sh
@@ -9,6 +9,7 @@ mkdir -p ${binpath%/*}
 upxflag=$(uci get AdGuardHome.AdGuardHome.upxflag 2>/dev/null)
 
 check_if_already_running(){
+    sleep 1
 	running_tasks="$(ps |grep "AdGuardHome" |grep "update_core" |grep -v "grep" |awk '{print $1}' |wc -l)"
 	[ "${running_tasks}" -gt "2" ] && echo -e "\nA task is already running."  && EXIT 2
 }


### PR DESCRIPTION
https://github-com.translate.goog/rufengsuixing/luci-app-adguardhome/pull/121?_x_tr_sl=auto&_x_tr_tl=en&_x_tr_hl=en&_x_tr_pto=wapp#issue-890914938

ohrws commented on 13 May 2021 • 
Version 21.02rc1

Fix the bug caused by reading the tmp/resolv.conf.auto file path error
Fix the js error caused by not getting this.XHR._q
Support the new version of Chinese package zh_Hans
Fix no option backupwdpath without uci, instead read the workdir field by default
Fix the exception that A task is already running may occur in check_if_already_running